### PR TITLE
Refactor: 관리자 페이지 컴포넌트 분리

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function UserPage() {
+  return <div>인증 관리 페이지입니다.</div>
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function UserPage() {
+  return <div>대시보드 페이지입니다.</div>;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,29 +1,35 @@
-import type React from "react"
-import "@/app/globals.css"
-import { Inter } from "next/font/google"
-import { ThemeProvider } from "@/components/theme-provider"
-import { AuthProvider } from "@/components/auth-provider"
+import { Inter } from "next/font/google";
+import "@/app/globals.css";
+import { ThemeProvider } from "@/components/theme-provider";
+import { AuthProvider } from "@/components/auth-provider";
+import LayoutWrapper from "@/components/layout/LayoutWrapper";
 
-const inter = Inter({ subsets: ["latin"] })
+const inter = Inter({ subsets: ["latin"] });
 
 export const metadata = {
   title: "관리자 대시보드",
   description: "관리자 대시보드 애플리케이션",
-    generator: 'v0.dev'
-}
+};
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
   return (
     <html lang="ko" suppressHydrationWarning>
       <body className={inter.className}>
-        <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
-          <AuthProvider>{children}</AuthProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="light"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <AuthProvider>
+            <LayoutWrapper>{children}</LayoutWrapper>
+          </AuthProvider>
         </ThemeProvider>
       </body>
     </html>
-  )
+  );
 }

--- a/app/login/components/LoginForm.tsx
+++ b/app/login/components/LoginForm.tsx
@@ -67,23 +67,13 @@ export default function LoginForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
     if (!validateForm()) return;
 
     setIsLoading(true);
+
     try {
-      const success = await login(
-        formData.email,
-        formData.password,
-        formData.rememberMe
-      );
-      if (success) {
-        router.push("/");
-      } else {
-        setErrors((prev) => ({
-          ...prev,
-          general: "이메일 또는 비밀번호가 올바르지 않습니다.",
-        }));
-      }
+      router.push("/dashboard");
     } catch (error) {
       setErrors((prev) => ({
         ...prev,

--- a/app/logs/page.tsx
+++ b/app/logs/page.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function UserPage() {
+  return <div>시스템 로그 페이지입니다.</div>
+}

--- a/app/merchant/page.tsx
+++ b/app/merchant/page.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function UserPage() {
+  return <div>판매자 관리 페이지입니다.</div>
+}

--- a/app/notice/page.tsx
+++ b/app/notice/page.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function UserPage() {
+  return <div>공지사항 관리 페이지입니다.</div>
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,67 +1,64 @@
-"use client"
+"use client";
 
-import { useState, useEffect } from "react"
-import { Button } from "@/components/ui/button"
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import VoucherIssueForm from "@/components/voucher-issue-form";
+import { VoucherContent } from "@/components/voucher-content";
+import { NoticeContent } from "@/components/notice-content";
+import { AuthContent } from "@/components/auth-content";
+import { PaymentContent } from "@/components/payment-content";
+import { MerchantContent } from "@/components/merchant-content";
+import { SystemLogContent } from "@/components/system-log-content";
 import {
-  Ticket,
-  Users,
-  FileText,
-  ShieldCheck,
-  CreditCard,
-  Store,
-  Terminal,
-  LogOut,
-  Menu,
-  BarChart3,
-} from "lucide-react"
-import VoucherIssueForm from "@/components/voucher-issue-form"
-import { VoucherContent } from "@/components/voucher-content"
-import { NoticeContent } from "@/components/notice-content"
-import { AuthContent } from "@/components/auth-content"
-import { PaymentContent } from "@/components/payment-content"
-import { MerchantContent } from "@/components/merchant-content"
-import { SystemLogContent } from "@/components/system-log-content"
-import { useAuth } from "@/components/auth-provider"
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 
-export default function Dashboard() {
-  const [activeTab, setActiveTab] = useState("dashboard")
-  const [showVoucherIssue, setShowVoucherIssue] = useState(false)
-  const [voucherToEdit, setVoucherToEdit] = useState(null)
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
-  const { logout } = useAuth()
+export default function Home() {
+  const [activeTab, setActiveTab] = useState("dashboard");
+  const [showVoucherIssue, setShowVoucherIssue] = useState(false);
+  const [voucherToEdit, setVoucherToEdit] = useState(null);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace("/login");
+  }, [router]);
 
   // 바우처 발행 폼 토글
   const toggleVoucherIssue = (voucher = null) => {
-    setVoucherToEdit(voucher)
-    setShowVoucherIssue(!showVoucherIssue)
-  }
+    setVoucherToEdit(voucher);
+    setShowVoucherIssue(!showVoucherIssue);
+  };
 
   // 바우처 발행 완료 핸들러
   const handleVoucherIssueComplete = () => {
-    setShowVoucherIssue(false)
-    setVoucherToEdit(null)
+    setShowVoucherIssue(false);
+    setVoucherToEdit(null);
     // 여기에 바우처 목록 새로고침 로직 추가
-  }
+  };
 
   // 탭 변경 핸들러
   const handleTabChange = (tab) => {
-    setActiveTab(tab)
-    setIsMobileMenuOpen(false) // 모바일에서 탭 선택 시 메뉴 닫기
-  }
+    setActiveTab(tab);
+    setIsMobileMenuOpen(false); // 모바일에서 탭 선택 시 메뉴 닫기
+  };
 
   // 현재 날짜 및 시간
-  const [currentDateTime, setCurrentDateTime] = useState(new Date())
+  const [currentDateTime, setCurrentDateTime] = useState(new Date());
 
   // 현재 시간 업데이트
   useEffect(() => {
     const timer = setInterval(() => {
-      setCurrentDateTime(new Date())
-    }, 60000) // 1분마다 업데이트
+      setCurrentDateTime(new Date());
+    }, 60000); // 1분마다 업데이트
 
-    return () => clearInterval(timer)
-  }, [])
+    return () => clearInterval(timer);
+  }, []);
 
   // 날짜 포맷팅
   const formatDate = (date) => {
@@ -70,185 +67,20 @@ export default function Dashboard() {
       month: "long",
       day: "numeric",
       weekday: "long",
-    })
-  }
+    });
+  };
 
   // 시간 포맷팅
   const formatTime = (date) => {
     return date.toLocaleTimeString("ko-KR", {
       hour: "2-digit",
       minute: "2-digit",
-    })
-  }
+    });
+  };
 
   return (
     <div className="flex flex-col h-screen">
-      {/* 상단 헤더 (모바일 및 데스크톱) */}
-      <header className="bg-white border-b px-4 py-3 flex items-center justify-between">
-        <div className="flex items-center">
-          <Sheet open={isMobileMenuOpen} onOpenChange={setIsMobileMenuOpen}>
-            <SheetTrigger asChild className="md:hidden">
-              <Button variant="ghost" size="icon">
-                <Menu className="h-5 w-5" />
-              </Button>
-            </SheetTrigger>
-            <SheetContent side="left" className="p-0 w-64">
-              <div className="p-4 border-b">
-                <h2 className="text-lg font-semibold">관리자 대시보드</h2>
-              </div>
-              <nav className="p-4 space-y-2">
-                <Button
-                  variant={activeTab === "dashboard" ? "default" : "ghost"}
-                  className="w-full justify-start"
-                  onClick={() => handleTabChange("dashboard")}
-                >
-                  <BarChart3 className="mr-2 h-4 w-4" />
-                  대시보드
-                </Button>
-                <Button
-                  variant={activeTab === "voucher" ? "default" : "ghost"}
-                  className="w-full justify-start"
-                  onClick={() => handleTabChange("voucher")}
-                >
-                  <Ticket className="mr-2 h-4 w-4" />
-                  바우처 관리
-                </Button>
-                <Button
-                  variant={activeTab === "user" ? "default" : "ghost"}
-                  className="w-full justify-start"
-                  onClick={() => handleTabChange("user")}
-                >
-                  <Users className="mr-2 h-4 w-4" />
-                  사용자 관리
-                </Button>
-                <Button
-                  variant={activeTab === "notice" ? "default" : "ghost"}
-                  className="w-full justify-start"
-                  onClick={() => handleTabChange("notice")}
-                >
-                  <FileText className="mr-2 h-4 w-4" />
-                  공지사항 관리
-                </Button>
-                <Button
-                  variant={activeTab === "auth" ? "default" : "ghost"}
-                  className="w-full justify-start"
-                  onClick={() => handleTabChange("auth")}
-                >
-                  <ShieldCheck className="mr-2 h-4 w-4" />
-                  인증 관리
-                </Button>
-                <Button
-                  variant={activeTab === "payment" ? "default" : "ghost"}
-                  className="w-full justify-start"
-                  onClick={() => handleTabChange("payment")}
-                >
-                  <CreditCard className="mr-2 h-4 w-4" />
-                  결제 관리
-                </Button>
-                <Button
-                  variant={activeTab === "merchant" ? "default" : "ghost"}
-                  className="w-full justify-start"
-                  onClick={() => handleTabChange("merchant")}
-                >
-                  <Store className="mr-2 h-4 w-4" />
-                  판매자 관리
-                </Button>
-                <Button
-                  variant={activeTab === "system" ? "default" : "ghost"}
-                  className="w-full justify-start"
-                  onClick={() => handleTabChange("system")}
-                >
-                  <Terminal className="mr-2 h-4 w-4" />
-                  시스템 로그
-                </Button>
-                <div className="pt-4 border-t mt-4">
-                  <Button variant="outline" className="w-full justify-start" onClick={logout}>
-                    <LogOut className="mr-2 h-4 w-4" />
-                    로그아웃
-                  </Button>
-                </div>
-              </nav>
-            </SheetContent>
-          </Sheet>
-          <h1 className="text-xl font-bold ml-2 md:ml-0">관리자 대시보드</h1>
-        </div>
-        <Button variant="ghost" size="sm" onClick={logout} className="hidden md:flex">
-          <LogOut className="mr-2 h-4 w-4" />
-          로그아웃
-        </Button>
-      </header>
-
       <div className="flex flex-1 overflow-hidden">
-        {/* 사이드바 (데스크톱) */}
-        <div className="w-64 border-r bg-muted/40 p-4 hidden md:block">
-          <nav className="space-y-2">
-            <Button
-              variant={activeTab === "dashboard" ? "default" : "ghost"}
-              className="w-full justify-start"
-              onClick={() => setActiveTab("dashboard")}
-            >
-              <BarChart3 className="mr-2 h-4 w-4" />
-              대시보드
-            </Button>
-            <Button
-              variant={activeTab === "voucher" ? "default" : "ghost"}
-              className="w-full justify-start"
-              onClick={() => setActiveTab("voucher")}
-            >
-              <Ticket className="mr-2 h-4 w-4" />
-              바우처 관리
-            </Button>
-            <Button
-              variant={activeTab === "user" ? "default" : "ghost"}
-              className="w-full justify-start"
-              onClick={() => setActiveTab("user")}
-            >
-              <Users className="mr-2 h-4 w-4" />
-              사용자 관리
-            </Button>
-            <Button
-              variant={activeTab === "notice" ? "default" : "ghost"}
-              className="w-full justify-start"
-              onClick={() => setActiveTab("notice")}
-            >
-              <FileText className="mr-2 h-4 w-4" />
-              공지사항 관리
-            </Button>
-            <Button
-              variant={activeTab === "auth" ? "default" : "ghost"}
-              className="w-full justify-start"
-              onClick={() => setActiveTab("auth")}
-            >
-              <ShieldCheck className="mr-2 h-4 w-4" />
-              인증 관리
-            </Button>
-            <Button
-              variant={activeTab === "payment" ? "default" : "ghost"}
-              className="w-full justify-start"
-              onClick={() => setActiveTab("payment")}
-            >
-              <CreditCard className="mr-2 h-4 w-4" />
-              결제 관리
-            </Button>
-            <Button
-              variant={activeTab === "merchant" ? "default" : "ghost"}
-              className="w-full justify-start"
-              onClick={() => setActiveTab("merchant")}
-            >
-              <Store className="mr-2 h-4 w-4" />
-              판매자 관리
-            </Button>
-            <Button
-              variant={activeTab === "system" ? "default" : "ghost"}
-              className="w-full justify-start"
-              onClick={() => setActiveTab("system")}
-            >
-              <Terminal className="mr-2 h-4 w-4" />
-              시스템 로그
-            </Button>
-          </nav>
-        </div>
-
         {/* 메인 콘텐츠 */}
         <div className="flex-1 overflow-auto">
           <div className="p-4 md:p-6">
@@ -291,36 +123,73 @@ export default function Dashboard() {
         </div>
       </div>
     </div>
-  )
+  );
 }
 
 // 대시보드 컴포넌트
 function DashboardContent() {
   // 샘플 데이터
   const stats = [
-    { title: "총 바우처 수", value: "1,234", change: "+12%", changeType: "increase" },
-    { title: "활성 사용자", value: "5,678", change: "+7.3%", changeType: "increase" },
-    { title: "판매자 수", value: "246", change: "+2.5%", changeType: "increase" },
-    { title: "이번 달 매출", value: "₩12,345,678", change: "-3.2%", changeType: "decrease" },
-  ]
+    {
+      title: "총 바우처 수",
+      value: "1,234",
+      change: "+12%",
+      changeType: "increase",
+    },
+    {
+      title: "활성 사용자",
+      value: "5,678",
+      change: "+7.3%",
+      changeType: "increase",
+    },
+    {
+      title: "판매자 수",
+      value: "246",
+      change: "+2.5%",
+      changeType: "increase",
+    },
+    {
+      title: "이번 달 매출",
+      value: "₩12,345,678",
+      change: "-3.2%",
+      changeType: "decrease",
+    },
+  ];
 
   const recentVouchers = [
-    { id: "V001", name: "맛있는 식당 30% 할인", status: "활성", date: "2023-05-15" },
-    { id: "V002", name: "행복 카페 아메리카노 1+1", status: "활성", date: "2023-05-14" },
-    { id: "V003", name: "뷰티살롱 헤어컷 50% 할인", status: "소진", date: "2023-05-12" },
-  ]
+    {
+      id: "V001",
+      name: "맛있는 식당 30% 할인",
+      status: "활성",
+      date: "2023-05-15",
+    },
+    {
+      id: "V002",
+      name: "행복 카페 아메리카노 1+1",
+      status: "활성",
+      date: "2023-05-14",
+    },
+    {
+      id: "V003",
+      name: "뷰티살롱 헤어컷 50% 할인",
+      status: "소진",
+      date: "2023-05-12",
+    },
+  ];
 
   const recentNotices = [
     { id: 1, title: "시스템 점검 안내", date: "2023-05-15" },
     { id: 2, title: "바우처 발행 정책 변경 안내", date: "2023-05-10" },
     { id: 3, title: "신규 판매자 등록 절차 안내", date: "2023-05-05" },
-  ]
+  ];
 
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold">대시보드</h1>
-        <p className="text-muted-foreground">시스템 현황 및 주요 지표를 확인하세요.</p>
+        <p className="text-muted-foreground">
+          시스템 현황 및 주요 지표를 확인하세요.
+        </p>
       </div>
 
       {/* 통계 카드 */}
@@ -329,12 +198,16 @@ function DashboardContent() {
           <Card key={index}>
             <CardContent className="p-6">
               <div className="flex flex-col gap-1">
-                <p className="text-sm font-medium text-muted-foreground">{stat.title}</p>
+                <p className="text-sm font-medium text-muted-foreground">
+                  {stat.title}
+                </p>
                 <div className="flex items-center justify-between">
                   <p className="text-2xl font-bold">{stat.value}</p>
                   <span
                     className={`text-xs font-medium ${
-                      stat.changeType === "increase" ? "text-green-500" : "text-red-500"
+                      stat.changeType === "increase"
+                        ? "text-green-500"
+                        : "text-red-500"
                     }`}
                   >
                     {stat.change}
@@ -357,18 +230,23 @@ function DashboardContent() {
           <CardContent>
             <div className="space-y-4">
               {recentVouchers.map((voucher) => (
-                <div key={voucher.id} className="flex items-center justify-between border-b pb-2 last:border-0">
+                <div
+                  key={voucher.id}
+                  className="flex items-center justify-between border-b pb-2 last:border-0"
+                >
                   <div>
                     <p className="font-medium">{voucher.name}</p>
-                    <p className="text-sm text-muted-foreground">{voucher.date}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {voucher.date}
+                    </p>
                   </div>
                   <span
                     className={`px-2 py-1 rounded-full text-xs ${
                       voucher.status === "활성"
                         ? "bg-green-100 text-green-800"
                         : voucher.status === "소진"
-                          ? "bg-orange-100 text-orange-800"
-                          : "bg-gray-100 text-gray-800"
+                        ? "bg-orange-100 text-orange-800"
+                        : "bg-gray-100 text-gray-800"
                     }`}
                   >
                     {voucher.status}
@@ -391,10 +269,15 @@ function DashboardContent() {
           <CardContent>
             <div className="space-y-4">
               {recentNotices.map((notice) => (
-                <div key={notice.id} className="flex items-center justify-between border-b pb-2 last:border-0">
+                <div
+                  key={notice.id}
+                  className="flex items-center justify-between border-b pb-2 last:border-0"
+                >
                   <div>
                     <p className="font-medium">{notice.title}</p>
-                    <p className="text-sm text-muted-foreground">{notice.date}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {notice.date}
+                    </p>
                   </div>
                 </div>
               ))}
@@ -446,7 +329,7 @@ function DashboardContent() {
         </CardContent>
       </Card>
     </div>
-  )
+  );
 }
 
 // 다른 컴포넌트들은 이전과 동일하게 유지
@@ -456,5 +339,5 @@ function UserContent() {
       <h1 className="text-2xl font-bold">사용자 관리</h1>
       <p>사용자 관리 컴포넌트가 여기에 표시됩니다.</p>
     </div>
-  )
+  );
 }

--- a/app/payment/page.tsx
+++ b/app/payment/page.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function UserPage() {
+  return <div>결제 관리 페이지입니다.</div>;
+}

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function UserPage() {
+  return <div>사용자 관리 페이지입니다.</div>
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Menu, LogOut } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetTrigger,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+
+import { useAuth } from "@/components/auth-provider";
+import Sidebar from "./Sidebar";
+
+export default function Header() {
+  const { logout } = useAuth();
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 768) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    handleResize();
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return (
+    <header className="bg-white border-b px-4 py-3 flex items-center justify-between md:px-6">
+      <Sheet open={isMobileMenuOpen} onOpenChange={setIsMobileMenuOpen}>
+        <SheetTrigger asChild className="md:hidden">
+          <Button variant="ghost" size="icon">
+            <Menu className="h-5 w-5" />
+          </Button>
+        </SheetTrigger>
+
+        <SheetContent side="left" className="p-0 w-64">
+          <SheetHeader className="border-b px-4 py-3">
+            <SheetTitle className="text-lg text-left font-semibold">
+              관리자 대시보드
+            </SheetTitle>
+          </SheetHeader>
+
+          <Sidebar isMobile onNavigate={() => setIsMobileMenuOpen(false)} />
+        </SheetContent>
+      </Sheet>
+
+      <h1 className="text-xl font-bold">관리자 대시보드</h1>
+
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={logout}
+        className="hidden md:flex"
+      >
+        <LogOut className="mr-2 h-4 w-4" />
+        로그아웃
+      </Button>
+    </header>
+  );
+}

--- a/components/layout/LayoutWrapper.tsx
+++ b/components/layout/LayoutWrapper.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import MainLayout from "./MainLayout";
+
+export default function LayoutWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const isLoginPage = pathname.startsWith("/login");
+
+  if (isLoginPage) return <>{children}</>;
+
+  return <MainLayout>{children}</MainLayout>;
+}

--- a/components/layout/MainLayout.tsx
+++ b/components/layout/MainLayout.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ReactNode } from "react";
+import Header from "./Header";
+import Sidebar from "./Sidebar";
+
+export default function MainLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col h-screen">
+      <Header />
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar />
+        <main className="flex-1 overflow-auto p-4 md:p-6 bg-background">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import {
+  BarChart3,
+  Ticket,
+  Users,
+  FileText,
+  ShieldCheck,
+  CreditCard,
+  Store,
+  Terminal,
+  LogOut,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/components/auth-provider";
+
+const menu = [
+  { label: "대시보드", icon: BarChart3, path: "/dashboard" },
+  { label: "바우처 관리", icon: Ticket, path: "/voucher" },
+  { label: "사용자 관리", icon: Users, path: "/user" },
+  { label: "공지사항 관리", icon: FileText, path: "/notice" },
+  { label: "인증 관리", icon: ShieldCheck, path: "/auth" },
+  { label: "결제 관리", icon: CreditCard, path: "/payment" },
+  { label: "판매자 관리", icon: Store, path: "/merchant" },
+  { label: "시스템 로그", icon: Terminal, path: "/logs" },
+];
+
+export default function Sidebar({
+  isMobile = false,
+  onNavigate,
+}: {
+  isMobile?: boolean;
+  onNavigate?: () => void;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { logout } = useAuth();
+
+  return (
+    <div
+      className={`${
+        isMobile ? "" : "hidden md:block"
+      } w-64 h-full bg-muted/40 border-r p-4`}
+    >
+      <nav className="space-y-2">
+        {menu.map(({ label, icon: Icon, path }) => (
+          <Button
+            key={path}
+            variant={pathname.startsWith(path) ? "default" : "ghost"}
+            className="w-full justify-start"
+            onClick={() => {
+              router.push(path);
+              onNavigate?.();
+            }}
+          >
+            <Icon className="mr-2 h-4 w-4" />
+            {label}
+          </Button>
+        ))}
+      </nav>
+
+      {isMobile && (
+        <div className="pt-4 border-t mt-4">
+          <Button
+            variant="outline"
+            className="w-full justify-start"
+            onClick={logout}
+          >
+            <LogOut className="mr-2 h-4 w-4" />
+            로그아웃
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #2 

## 📌 개요
1. 공통 레이아웃 생성 및 적용
2. 대시보드

## 🔁 변경 사항
1. 공통 레이아웃 생성 및 적용
- components/layout/MainLayout.tsx, Header.tsx, Sidebar.tsx 생성 후 분리
- LayoutWrapper.tsx 생성 → 로그인 페이지에서는 MainLayout 제외
- 모바일 Sheet 사이드바 열림 상태에서 브라우저 width 커질 경우 자동 닫힘 처리
- 모바일 전용 사이드바에만 로그아웃 버튼 표시 (isMobile 분기)

## 📸 스크린샷 (선택)
1. 공통 레이아웃 생성 및 적용
![image](https://github.com/user-attachments/assets/721f206c-7325-460d-8c19-c35722f5ba06)

## 👀 기타 더 이야기해볼 점 (선택)
- 1. 로그인 로직은 백엔드 연동 전 단계이며, 추후 login() API로 교체 필요

## 💬 리뷰 요구사항 (선택)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
