### PR TITLE
✨ Feat/#13 transaction 대시보드 구현 완료

### DIFF
--- a/app/payment/page.tsx
+++ b/app/payment/page.tsx
@@ -1,5 +1,0 @@
-"use client";
-
-export default function UserPage() {
-  return <div>결제 관리 페이지입니다.</div>;
-}

--- a/app/transaction/api/transaction-api.ts
+++ b/app/transaction/api/transaction-api.ts
@@ -1,0 +1,32 @@
+import axios from "axios";
+import { getApiUrl } from "@/lib/getApiUrl";
+
+const API_URL = getApiUrl();
+
+/**
+ * 거래 목록을 불러옵니다.
+ * @param params page: 0부터 시작, type: DEPOSIT 등, status: PENDING 등
+ */
+export async function fetchTransactions(params: {
+    page?: number;
+    type?: string;
+    status?: string;
+}) {
+    const query = new URLSearchParams();
+
+    if (params.page !== undefined) query.append("page", params.page.toString());
+    query.append("size", "10"); // 페이지당 항목 수 고정
+
+    if (params.type) query.append("type", params.type);
+    if (params.status) query.append("status", params.status);
+
+    const url = `${API_URL}/admin-api/transactions?${query.toString()}`;
+
+    const response = await axios.get(url);
+    return response.data; // { isSuccess, code, message, result: {...page info...} }
+}
+export async function fetchTransactionDetail(id: number) {
+    const url = `${API_URL}/admin-api/transactions/${id}`;
+    const res = await axios.get(url);
+    return res.data;
+}

--- a/app/transaction/componets/TransactionDetailDialog.tsx
+++ b/app/transaction/componets/TransactionDetailDialog.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { fetchTransactionDetail } from "../api/transaction-api"; // API 연결 필요
+
+export interface Transaction {
+    id: number;
+    type: string;
+    amount: number;
+    status: string;
+    txHash: string;
+    createdAt: string;
+    description?: string;
+    traceId?: string;
+    walletId?: number;
+    failureReason?: string;
+}
+
+interface Props {
+    open: boolean;
+    transaction: { id: number } | null; // 전달되는 초기 ID만 필요
+    onClose: () => void;
+}
+
+export default function TransactionDetailDialog({ open, transaction, onClose }: Props) {
+    const [detail, setDetail] = useState<Transaction | null>(null);
+
+    useEffect(() => {
+        if (open && transaction?.id) {
+            fetchTransactionDetail(transaction.id)
+                .then((res) => setDetail(res.result))
+                .catch((err) => {
+                    console.error("거래 상세 조회 실패", err);
+                    setDetail(null);
+                });
+        }
+    }, [open, transaction]);
+
+    if (!detail) return null;
+
+    const badgeColor = {
+        SUCCESS: "bg-green-100 text-green-800",
+        FAILED: "bg-red-100 text-red-800",
+        PENDING: "bg-yellow-100 text-yellow-800",
+    }[detail.status] || "bg-gray-100 text-gray-800";
+
+    return (
+        <Dialog open={open} onOpenChange={onClose}>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>거래 상세 정보</DialogTitle>
+                </DialogHeader>
+
+                <div className="py-4 space-y-4 text-sm">
+                    <div className="grid grid-cols-4 gap-4">
+                        <div className="font-semibold">ID</div>
+                        <div className="col-span-3">{detail.id}</div>
+
+                        <div className="font-semibold">유형</div>
+                        <div className="col-span-3">{detail.type}</div>
+
+                        <div className="font-semibold">상태</div>
+                        <div className="col-span-3">
+                            <Badge className={badgeColor}>{detail.status}</Badge>
+                        </div>
+
+                        <div className="font-semibold">금액</div>
+                        <div className="col-span-3">{detail.amount.toLocaleString()}원</div>
+
+                        <div className="font-semibold">Tx Hash</div>
+                        <div className="col-span-3 break-all font-mono">{detail.txHash || "-"}</div>
+
+                        <div className="font-semibold">지갑 ID</div>
+                        <div className="col-span-3">{detail.walletId ?? "-"}</div>
+
+                        <div className="font-semibold">설명</div>
+                        <div className="col-span-3">{detail.description || "-"}</div>
+
+                        <div className="font-semibold">실패 사유</div>
+                        <div className="col-span-3 text-red-600">{detail.failureReason || "-"}</div>
+
+                        <div className="font-semibold">Trace ID</div>
+                        <div className="col-span-3 font-mono text-sm">{detail.traceId || "-"}</div>
+
+                        <div className="font-semibold">생성일시</div>
+                        <div className="col-span-3">
+                            {new Date(detail.createdAt).toLocaleString("ko-KR")}
+                        </div>
+                    </div>
+                </div>
+
+                <DialogFooter>
+                    <Button variant="outline" onClick={onClose}>
+                        닫기
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/app/transaction/page.tsx
+++ b/app/transaction/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { RefreshCcw, Eye } from "lucide-react";
+import List from "@/components/common/List";
+import { fetchTransactions } from "./api/transaction-api";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import TransactionDetailDialog from "@/app/transaction/componets/TransactionDetailDialog";
+
+interface Transaction {
+  id: number;
+  type: string;
+  amount: number;
+  status: string;
+  txHash: string;
+  createdAt: string;
+  description?: string;
+  traceId?: string;
+  walletId?: number;
+  failureReason?: string;
+}
+
+export default function TransactionPage() {
+  const [transactionList, setTransactionList] = useState<Transaction[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [selectedType, setSelectedType] = useState<string>("all");
+  const [selectedStatus, setSelectedStatus] = useState<string>("all");
+  const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
+
+  const fetchTransactionData = async (page = 0) => {
+    try {
+      const res = await fetchTransactions({
+        page,
+        type: selectedType !== "all" ? selectedType : undefined,
+        status: selectedStatus !== "all" ? selectedStatus : undefined,
+      });
+
+      const pageData = res.result;
+      setTransactionList(pageData.content);
+      setTotalPages(pageData.totalPages);
+      setCurrentPage(pageData.number + 1);
+    } catch (err) {
+      console.error("거래 목록 불러오기 실패", err);
+    }
+  };
+
+  useEffect(() => {
+    fetchTransactionData(currentPage - 1);
+  }, [selectedType, selectedStatus]);
+
+  const handleResetFilters = () => {
+    setSelectedType("all");
+    setSelectedStatus("all");
+    setCurrentPage(1);
+    fetchTransactionData(0);
+  };
+
+  const transactionColumns = [
+    { key: "id", header: "ID", cell: (tx: Transaction) => <span>{tx.id}</span> },
+    {
+      key: "type",
+      header: "유형",
+      cell: (tx: Transaction) => (
+          <Badge
+              className={
+                tx.type === "DEPOSIT"
+                    ? "bg-blue-100 text-blue-800"
+                    : tx.type === "PURCHASE"
+                        ? "bg-green-100 text-green-800"
+                        : tx.type === "RECEIVE"
+                            ? "bg-purple-100 text-purple-800"
+                            : "bg-gray-100 text-gray-800"
+              }
+          >
+            {tx.type}
+          </Badge>
+      ),
+    },
+    {
+      key: "amount",
+      header: "금액",
+      cell: (tx: Transaction) => <span>{tx.amount.toLocaleString()}원</span>,
+    },
+    {
+      key: "status",
+      header: "상태",
+      cell: (tx: Transaction) => (
+          <Badge
+              className={
+                tx.status === "SUCCESS"
+                    ? "bg-green-100 text-green-800"
+                    : tx.status === "PENDING"
+                        ? "bg-yellow-100 text-yellow-800"
+                        : "bg-red-100 text-red-800"
+              }
+          >
+            {tx.status}
+          </Badge>
+      ),
+    },
+    {
+      key: "txHash",
+      header: "Tx Hash",
+      cell: (tx: Transaction) => <span className="break-all">{tx.txHash || "-"}</span>,
+    },
+    {
+      key: "createdAt",
+      header: "거래일시",
+      cell: (tx: Transaction) => new Date(tx.createdAt).toLocaleString("ko-KR"),
+    },
+    {
+      key: "actions",
+      header: "관리",
+      cell: (tx: Transaction) => (
+          <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setSelectedTransaction(tx)}
+          >상세
+          </Button>
+      ),
+    },
+  ];
+
+  return (
+      <div className="space-y-6">
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+          <h1 className="text-2xl font-bold">거래 내역</h1>
+          <div className="flex flex-col md:flex-row gap-2">
+            <Select value={selectedType} onValueChange={setSelectedType}>
+              <SelectTrigger className="w-[130px]">
+                <SelectValue placeholder="유형" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">전체 유형</SelectItem>
+                <SelectItem value="DEPOSIT">입금</SelectItem>
+                <SelectItem value="PURCHASE">구매</SelectItem>
+                <SelectItem value="RECEIVE">수령</SelectItem>
+                <SelectItem value="CONVERT">전환</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Select value={selectedStatus} onValueChange={setSelectedStatus}>
+              <SelectTrigger className="w-[130px]">
+                <SelectValue placeholder="상태" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">전체 상태</SelectItem>
+                <SelectItem value="SUCCESS">성공</SelectItem>
+                <SelectItem value="PENDING">대기</SelectItem>
+                <SelectItem value="FAILURE">실패</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Button variant="outline" className="gap-1" onClick={handleResetFilters}>
+              <RefreshCcw className="h-4 w-4" /> 새로고침
+            </Button>
+          </div>
+        </div>
+
+        <List
+            data={transactionList}
+            columns={transactionColumns}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={(page) => fetchTransactionData(page - 1)}
+        />
+
+        {selectedTransaction && (
+            <TransactionDetailDialog
+                open={!!selectedTransaction}
+                transaction={selectedTransaction}
+                onClose={() => setSelectedTransaction(null)}
+            />
+        )}
+      </div>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -21,7 +21,7 @@ const menu = [
   { label: "사용자 관리", icon: Users, path: "/user" },
   { label: "공지사항 관리", icon: FileText, path: "/notice" },
   { label: "인증 관리", icon: ShieldCheck, path: "/auth" },
-  { label: "결제 관리", icon: CreditCard, path: "/payment" },
+  { label: "결제 관리", icon: CreditCard, path: "/transaction" },
   { label: "판매자 관리", icon: Store, path: "/merchant" },
   { label: "시스템 로그", icon: Terminal, path: "/system-logs" },
   { label: "API 요청 로그", icon: Terminal, path: "/api-logs" },


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #13 

## 📌 개요
-  관리자 페이지 트랜잭션 로그를 조회하는 대시보드를 구현하였습니다.
- 리스트 조회 페이지에서 상태 값 , 유형별로 필터 기능을 추가하였습니다.
- 새로고침 버튼 클릭시 모든 필터 조건을 초기화 하고 최신 로그를 불러옵니다.
## 🔁 변경 사항
- Package명을 Payment에서 Transaction으로 변경함.

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/d0fca333-acf6-4653-807c-f3821dbe9a97)
![image](https://github.com/user-attachments/assets/85220455-2f89-433d-ad39-5fb9dd4a7898)

## 👀 기타 더 이야기해볼 점 (선택)

## 💬 리뷰 요구사항 (선택)

## ✅ 체크 리스트
- [X] PR 템플릿에 맞추어 작성했어요.
- [X] 변경 내용에 대한 테스트를 진행했어요.
- [X] 프로그램이 정상적으로 동작해요.
- [X] PR에 적절한 라벨을 선택했어요.
- [X] 불필요한 코드는 삭제했어요.
